### PR TITLE
[WIP] Haskell base

### DIFF
--- a/dockerfiles/haskell-x509/Dockerfile
+++ b/dockerfiles/haskell-x509/Dockerfile
@@ -2,7 +2,7 @@ FROM ouspg/libfuzzer-base-haskell
 
 MAINTAINER https://github.com/ouspg/libfuzzerification
 
-WORKDIR /src
+WORKDIR /haskell
 RUN cabal update && cabal install x509
-COPY test.hs build.sh /src/
+COPY test.hs build.sh /haskell/
 RUN sh ./build.sh

--- a/dockerfiles/haskell-x509/build.sh
+++ b/dockerfiles/haskell-x509/build.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-GHCOPTS="-Wall -package bytestring -package cryptohash -package directory -package x509"
+set -ex
 
+GHCOPTS="-Wall -package libfuzzer -package x509"
+
+clang -Wall -c -I/opt/ghc/8.0.1/lib/ghc-8.0.1/include/ hsinit.c
 ghc-asan ${GHCOPTS} -c test.hs
-ghc-wrapper ${GHCOPTS} -no-hs-main -o test test.o /work/libfuzzer/*.o
+ghc-wrapper ${GHCOPTS} -no-hs-main -lFuzzer -o test test.o hsinit.o

--- a/dockerfiles/haskell-x509/test.hs
+++ b/dockerfiles/haskell-x509/test.hs
@@ -8,44 +8,15 @@ import Foreign.C.Types
 import Foreign.C.String
 import qualified Data.ByteString as BS
 
-import Control.Monad
-import Control.Exception
+import Libfuzzer
+import Control.Exception (SomeException, try, evaluate)
+
 import qualified Data.X509 as X509
-
-import Data.Byteable (toBytes)
-import System.IO
-import System.Directory (createDirectoryIfMissing, doesFileExist)
-import Crypto.Hash.SHA1 (hash)
-import qualified Data.ByteString.Char8 as Char8
-import qualified Data.ByteArray.Encoding as BA
-
--- extern "C" int LLVMFuzzerTestOneInput(uint8_t *data, size_t size)
-foreign export ccall "LLVMFuzzerTestOneInput" testOneInputM :: CString -> CSize -> IO CInt
-
-hashInHex :: String -> String
-hashInHex = hashInHexBS . Char8.pack
-
-hashInHexBS :: BS.ByteString -> String
-hashInHexBS =  Char8.unpack . BA.convertToBase BA.Base16 . toBytes . hash
-
-storeTestCase :: String -> BS.ByteString -> IO ()
-storeTestCase name content =
-  -- Use first 60 bytes for generating directory name.  This adds
-  -- different variants of almost same exception into same directory
-  let dir = "results/" ++ hashInHex (take 60 name)
-      file = hashInHexBS content
-  in do
-    createDirectoryIfMissing True dir
-    hasReadme <- doesFileExist $ dir ++ "/00README"
-    unless hasReadme (
-      withFile (dir ++ "/00README") WriteMode $ \h ->
-          BS.hPut h $ Char8.pack (name ++ "\n")
-      )
-    withFile (dir ++ "/" ++ file) WriteMode $ \h ->
-      BS.hPut h content
 
 decode :: BS.ByteString -> IO (Either SomeException (Either String X509.SignedCertificate))
 decode = try . evaluate . X509.decodeSignedCertificate
+
+foreign export ccall "LLVMFuzzerTestOneInput" testOneInputM :: CString -> CSize -> IO CInt
 
 testOneInputM :: CString -> CSize -> IO CInt
 testOneInputM str size = do

--- a/dockerfiles/libfuzzer-base-haskell/Dockerfile
+++ b/dockerfiles/libfuzzer-base-haskell/Dockerfile
@@ -34,13 +34,18 @@ RUN update-alternatives --install /usr/bin/opt opt /usr/bin/opt-${GHC_LLVM} 1 &&
 
 ENV PATH /opt/ghc/${GHC_VERSION}/bin/:/opt/cabal/${CABAL_VERSION}/bin/:${PATH}
 
-RUN cabal update && cabal install cryptohash
-
-RUN mkdir -p /root/.cabal/
-COPY cabal.config /root/.cabal/config
-
 COPY ghc-wrapper ghc-asan /usr/local/bin/
 RUN chmod a+x /usr/local/bin/ghc-*
+
+# Build and install our libfuzzer Haskell lib
+WORKDIR /src/hs-libfuzzer
+ADD hs-libfuzzer /src/hs-libfuzzer
+RUN cd /src/hs-libfuzzer && \
+    cabal update && \
+    cabal install && \
+    rm -rf /src/hs-libfuzzer
+
+COPY cabal.config /root/.cabal/config
 
 WORKDIR /haskell/
 COPY src/hsinit.c src/test.hs src/build.sh /haskell/

--- a/dockerfiles/libfuzzer-base-haskell/hs-libfuzzer/LICENSE
+++ b/dockerfiles/libfuzzer-base-haskell/hs-libfuzzer/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Oulu University Secure Programming Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dockerfiles/libfuzzer-base-haskell/hs-libfuzzer/Setup.hs
+++ b/dockerfiles/libfuzzer-base-haskell/hs-libfuzzer/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/dockerfiles/libfuzzer-base-haskell/hs-libfuzzer/libfuzzer.cabal
+++ b/dockerfiles/libfuzzer-base-haskell/hs-libfuzzer/libfuzzer.cabal
@@ -1,0 +1,24 @@
+name:                libfuzzer
+version:             0.1.0.0
+synopsis:            Libfuzzer utils to help with fuzzing
+description:         Please see README.md
+homepage:            https://github.com/ouspg/libfuzzerfication/
+license:             MIT
+license-file:        LICENSE
+maintainer:          https://github.com/ouspg/libfuzzerfication/
+copyright:           2016 OUSPG
+category:            Testing
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  exposed-modules:     Libfuzzer
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+  build-depends:       base >= 4.7 && < 5
+                     , byteable
+                     , bytestring
+                     , cryptohash
+                     , directory
+                     , memory

--- a/dockerfiles/libfuzzer-base-haskell/hs-libfuzzer/src/Libfuzzer.hs
+++ b/dockerfiles/libfuzzer-base-haskell/hs-libfuzzer/src/Libfuzzer.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Libfuzzer
+  (
+    storeTestCase
+  ) where
+
+import Control.Monad (unless)
+import Crypto.Hash.SHA1 (hash)
+import Data.Byteable (toBytes)
+import System.Directory (createDirectoryIfMissing, doesFileExist)
+import System.IO (withFile, IOMode(..))
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as Char8
+import qualified Data.ByteArray.Encoding as BA
+
+hashInHex :: String -> String
+hashInHex = hashInHexBS . Char8.pack
+
+hashInHexBS :: BS.ByteString -> String
+hashInHexBS =  Char8.unpack . BA.convertToBase BA.Base16 . toBytes . hash
+
+storeTestCase :: String -> BS.ByteString -> IO ()
+storeTestCase name content =
+  -- Use first 60 bytes for generating directory name. This adds
+  -- different variants of almost same exception into same directory
+  let dir = "results/" ++ hashInHex (take 60 name)
+      file = hashInHexBS content
+      readme = dir ++ "/00README"
+  in do
+    createDirectoryIfMissing True dir
+    hasReadme <- doesFileExist readme
+    unless hasReadme (
+      withFile readme WriteMode $ \h ->
+          BS.hPut h $ Char8.pack (name ++ "\n")
+      )
+    withFile (dir ++ "/" ++ file) WriteMode $ \h ->
+      BS.hPut h content

--- a/dockerfiles/libfuzzer-base-haskell/hs-libfuzzer/stack.yaml
+++ b/dockerfiles/libfuzzer-base-haskell/hs-libfuzzer/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-6.4
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []

--- a/dockerfiles/libfuzzer-base-haskell/src/build.sh
+++ b/dockerfiles/libfuzzer-base-haskell/src/build.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-GHCOPTS="-package bytestring"
+GHCOPTS="-package libfuzzer"
 
 clang -Wall -c -I/opt/ghc/8.0.1/lib/ghc-8.0.1/include/ hsinit.c
 ghc-asan ${GHCOPTS} -c test.hs

--- a/dockerfiles/libfuzzer-base-haskell/src/test.hs
+++ b/dockerfiles/libfuzzer-base-haskell/src/test.hs
@@ -2,12 +2,13 @@
 
 module Test where
 
+import Libfuzzer (storeTestCase)
+
 import Foreign.C.Types
 import Foreign.C.String
 
 import qualified Data.ByteString as BS
 
--- extern "C" int LLVMFuzzerTestOneInput(uint8_t *data, size_t size)
 foreign export ccall "LLVMFuzzerTestOneInput" testOneInputM :: CString -> CSize -> IO CInt
 
 testOneInputM :: CString -> CSize -> IO CInt


### PR DESCRIPTION
Tweaks to Haskell fuzzing

`hs-libfuzzer` is proper Haskell package to be installed (it can be found under dir `dockerfiles/libfuzzer-base-haskell/hs-libfuzzer/`). It should be collection of utility functions used for writing stubs. Everything used more than in one container should probably be captured here. Keep stubs simple and build library for helping with things. Licenced under MIT if that's anything important.

Convert `haskell-x509` to use `hs-libfuzzer`. `haskell-x509` right now tries to set an example and also be my guinnea pig for different ideas how to go forward.
