### PR TITLE
Add nipsu minimizer to libfuzzer-base

### DIFF
--- a/docker/base/libfuzzer-base/Dockerfile
+++ b/docker/base/libfuzzer-base/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:16.04
 RUN apt-get update && \
 	apt-get upgrade -y && \
-	apt-get install -y  git clang
+	apt-get install -y git clang nodejs && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
 
 # Checkout & build libFuzzer
 #
@@ -14,6 +16,13 @@ RUN mkdir /src /work && \
 	mv libFuzzer.a /usr/local/lib && \
 	rm *.o && \
 	rm -rf Fuzzer
+
+
+#Checkout minimizer
+#
+RUN cd src && \
+	git clone https://github.com/attekett/nipsu/ && \
+	rm -rf ./nipsu/.git
 
 # Add fuzzing script
 #

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,9 @@ services:
   libfuzzer-base:
       build: ./base/libfuzzer-base
       image: ouspg/libfuzzer-base
+  
+## ImageMagick stub, with automatic crash-repro minimizer
+
   ImageMagick:
       build: ./stubs/ImageMagick
       image: ouspg/libfuzzer-imagemagick
@@ -20,6 +23,8 @@ services:
         - ~/samples/:/samples
       mem_limit: 4g
       shm_size: 512M
+      environment:
+        MINIMIZE: "true"
       entrypoint: '/src/scripts/fuzz.sh'
       command: [
         '/src/ImageMagick/ImageMagick_fuzzer',
@@ -27,7 +32,6 @@ services:
         '-detect_leaks=0',
         '-exact_artifact_path=/dev/shm/repro-file',
         '-max_len=1000',
-        '-timeout=5',
         '-use_counters=1',
         '-max_total_time=3600',
         '/samples/libfuzzer-imagemagick'

--- a/docker/stubs/libxml2/Dockerfile
+++ b/docker/stubs/libxml2/Dockerfile
@@ -2,7 +2,7 @@ FROM ouspg/libfuzzer-base
 
 MAINTAINER https://github.com/ouspg/libfuzzerification
 
-RUN apt-get install -y liblzma-dev
+RUN apt-get update && apt-get install -y liblzma-dev
 RUN apt-get build-dep libxml2 -y
 RUN cd /src && git clone git://git.gnome.org/libxml2
 


### PR DESCRIPTION
Add [nipsu](https://github.com/attekett/nipsu) minimizer to minimize all repro-files caught by AddressSanitizer hook in fuzz.sh.

You can enable automatic minimizer by setting MINIMIZE environment variable to "true", either from docker-compose.yml environment, or docker run -e "MINIMIZE=true".

With minimizer enabled, addition to the original crash reproducing file, the minimized file will be saved in the results directory.

Original crash reproducing file: /results/$TARGET-$RESULT.repro
Minimized: /results/$TARGET-$RESULT-min.repro

With these changes the libfuzzer-base image size increases from 646.7MB to 653.3MB.
