### PR TITLE
fix docker compose pathes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       image: ouspg/libfuzzer-imagemagick
       volumes:
         - ~/results/:/srv/fuzzer/results/
-        #- ~/samples/:/srv/fuzzer/samples/
+        - ~/samples/:/srv/fuzzer/samples/
       mem_limit: 4g
       shm_size: 512M
       environment:
@@ -34,7 +34,7 @@ services:
         '-max_len=1000',
         '-use_counters=1',
         '-max_total_time=3600',
-        '/srv/fuzzer/samples/'
+        '/srv/fuzzer/samples/libfuzzer-imagemagick'
       ]
 
 ## libxml2 stub
@@ -46,7 +46,7 @@ services:
       mem_limit: 4g
       volumes:
           - ~/results/:/srv/fuzzer/results/
-          #- ~/samples/:/srv/fuzzer/samples/
+          - ~/samples/:/srv/fuzzer/samples/
       environment:
           LD_LIBRARY_PATH: "/src/libxml2/.libs/"
       command: [
@@ -57,7 +57,7 @@ services:
         '-max_len=5000',
         '-use_counters=1',
         '-max_total_time=600',
-        '/srv/fuzzer/samples/'
+        '/srv/fuzzer/samples/libfuzzer-libxml2/'
       ]
 
 ## libxslt
@@ -69,7 +69,7 @@ services:
       mem_limit: 4g
       volumes:
           - ~/results/:/srv/fuzzer/results/
-          #- ~/samples/:/srv/fuzzer/samples/
+          - ~/samples/:/srv/fuzzer/samples/
       environment:
           LD_LIBRARY_PATH: "/src/libxslt/libxslt/.libs/"
       command: [
@@ -80,7 +80,7 @@ services:
         '-max_len=5000',
         '-use_counters=1',
         '-max_total_time=600',
-        '/srv/fuzzer/samples/'
+        '/srv/fuzzer/samples/libfuzzer-libxslt'
       ]
 
 ## libav stub
@@ -103,7 +103,7 @@ services:
         '-timeout=5',
         '-use_counters=1',
         '-max_total_time=3600',
-        '/srv/fuzzer/samples/'
+        '/srv/fuzzer/samples/libfuzzer-libav'
       ]
 
 ## lua stub
@@ -126,7 +126,7 @@ services:
         '-timeout=5',
         '-use_counters=1',
         '-max_total_time=3600',
-        '/srv/fuzzer/samples/'
+        '/srv/fuzzer/samples/libfuzzer-lua'
       ]
 
 ## libmad stub
@@ -136,7 +136,7 @@ services:
       image: ouspg/libfuzzer-libmad
       volumes:
         - ~/results/:/srv/fuzzer/results/
-        #- ~/samples/:/srv/fuzzer/samples/
+        - ~/samples/:/srv/fuzzer/samples/
       mem_limit: 4g
       shm_size: 512M
       entrypoint: '/src/scripts/fuzz.sh'
@@ -148,7 +148,7 @@ services:
         '-max_len=1000',
         '-use_counters=1',
         '-max_total_time=3600',
-        '/srv/fuzzer/samples/'
+        '/srv/fuzzer/samples/libfuzzer-libmad'
       ]
 
 ## zlib stub
@@ -170,7 +170,7 @@ services:
         '-max_len=1000',
         '-use_counters=1',
         '-max_total_time=3600',
-        '/srv/fuzzer/samples/'
+        '/srv/fuzzer/samples/libfuzzer-zlib'
       ]
 
 ## Haskell base image

--- a/stubs/ImageMagick/Dockerfile
+++ b/stubs/ImageMagick/Dockerfile
@@ -20,7 +20,7 @@ RUN cd /src && git clone https://github.com/ImageMagick/ImageMagick.git
 ADD ImageMagick-fuzzer.c /src/ImageMagick/
 RUN mkdir -p /work/ImageMagick/
 
-ADD samples.tar /srv/fuzzer
+#ADD samples.tar /srv/fuzzer
 
 # Build
 

--- a/stubs/libmad/Dockerfile
+++ b/stubs/libmad/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get build-dep libmad0 -y
 #Download source, extract and remove downloaded files.
 RUN mkdir -p /src/ && cd /src/ && apt-get source libmad0 && ls -p | grep -v / | xargs rm
 
-ADD samples.tar /srv/fuzzer
+#ADD samples.tar /srv/fuzzer
 
 #Copy stub
 ADD libmad-fuzzer.c /src/libmad-0.15.1b/

--- a/stubs/libxml2/Dockerfile
+++ b/stubs/libxml2/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y liblzma-dev
 RUN apt-get build-dep libxml2 -y
 RUN cd /src && git clone git://git.gnome.org/libxml2
 
-ADD samples.tar /srv/fuzzer
+#ADD samples.tar /srv/fuzzer
 
 RUN export LD_LIBRARY_PATH="/src/libxml2/.libs/"
 

--- a/stubs/libxslt/Dockerfile
+++ b/stubs/libxslt/Dockerfile
@@ -12,7 +12,7 @@ RUN cd /src && git clone git://git.gnome.org/libxslt
 
 RUN export LD_LIBRARY_PATH="/src/libxslt/libxslt/.libs/"
 
-ADD samples.tar /srv/fuzzer
+#ADD samples.tar /srv/fuzzer
 
 ADD libxslt-fuzzer.cc /src/libxslt/
 #ADD xslt.dict /src/libxslt/


### PR DESCRIPTION
Fixed docker-compose.yml sample pathes, modified dockerfiles so that samples are not added from tar files now
